### PR TITLE
fix: Use newer version of Twitch cdn for Twitch emotes

### DIFF
--- a/src/js/perplex-chat.ts
+++ b/src/js/perplex-chat.ts
@@ -120,7 +120,7 @@ function displayMessage (msg: PrivmsgMessage | UsernoticeMessage) {
         const matchesBTTV = bttvEmotes.find(emote => emote.code === word)
 
         if (matchesTwitch != null) {
-          url = `//static-cdn.jtvnw.net/emoticons/v1/${matchesTwitch.id}/3.0`
+          url = `//static-cdn.jtvnw.net/emoticons/v2/${matchesTwitch.id}/default/dark/3.0`
         } else if (matchesFFZ != null) {
           const emoteUrls = Object.keys(matchesFFZ.urls).map(key => matchesFFZ.urls[key])
           url = emoteUrls[emoteUrls.length - 1]


### PR DESCRIPTION
This change will make animated emotes no longer show up as static png's

Example:
v1:
<https://static-cdn.jtvnw.net/emoticons/v1/emotesv2_117f2dcc3f684334bae22981175acd62/3.0>
v2 (animated, default):
<https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_117f2dcc3f684334bae22981175acd62/default/dark/3.0>
v2 (static):
<https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_117f2dcc3f684334bae22981175acd62/static/dark/3.0>